### PR TITLE
also list any failed tests at the end of test_runner output

### DIFF
--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -367,7 +367,7 @@ def run_tests(test_list, src_dir, build_dir, exeext, tmpdir, jobs=1, enable_cove
 def print_results(test_results, max_len_name, runtime):
     results = "\n" + BOLD[1] + "%s | %s | %s\n\n" % ("TEST".ljust(max_len_name), "STATUS   ", "DURATION") + BOLD[0]
 
-    test_results.sort(key=lambda result: result.name.lower())
+    test_results.sort(key=TestResult.sort_key)
     all_passed = True
     time_sum = 0
 
@@ -458,6 +458,14 @@ class TestResult():
         self.status = status
         self.time = time
         self.padding = 0
+
+    def sort_key(self):
+        if self.status == "Passed":
+            return 1, self.name.lower()
+        elif self.status == "Failed":
+            return 2, self.name.lower()
+        elif self.status == "Skipped":
+            return 0, self.name.lower()
 
     def __repr__(self):
         if self.status == "Passed":


### PR DESCRIPTION
just a suggestion. this makes the output look like:

```
wallet_resendwallettransactions.py    | ✓ Passed  | 2 s
wallet_txn_clone.py                   | ✓ Passed  | 5 s
wallet_txn_clone.py --segwit          | ✓ Passed  | 3 s
wallet_txn_doublespend.py --mineblock | ✓ Passed  | 5 s
wallet_zapwallettxes.py               | ✓ Passed  | 4 s
feature_blocksdir.py                  | ✖ Failed  | 2 s

ALL                                   | ✖ Failed  | 1486 s (accumulated) 
```

with the failed ones all at the end and easy to see.